### PR TITLE
remove: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @twisttaan
-* @nciklol


### PR DESCRIPTION
Instead of using code owners to manage who has to review the code; use the organisation team feature.